### PR TITLE
Use paths to polymer/SimpleSlider without bower_components

### DIFF
--- a/src/simple-slider.html
+++ b/src/simple-slider.html
@@ -1,6 +1,6 @@
-<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../../polymer/polymer.html">
 
-<script src="../bower_components/SimpleSlider/dist/simpleslider.min.js"></script>
+<script src="../../SimpleSlider/dist/simpleslider.min.js"></script>
 
 <polymer-element name="simple-slider" constructor="SimpleSliderElement" attributes="transition-property transition-duration transition-delay start-value visible-value end-value auto-play">
 


### PR DESCRIPTION
Hi!

First of all - thanks for this element :)

I'm using it with `bower` and this caused me a path problem. I've looked into core-elements source code, and they all are using paths without `bower_components`. As you've put this into `src` directory, i would like to suggest `../../polymer/polymer.html` import (which works well with my configuration).

What do you think?

Best regards,
Kacper.
