### PR TITLE
add option to auto reload slider when child nodes are updated

### DIFF
--- a/simple-slider.html
+++ b/simple-slider.html
@@ -16,7 +16,8 @@
       startValue: { type: String },
       visibleValue: { type: String },
       endValue: { type: String },
-      noAutoPlay: { type: Boolean }
+      noAutoPlay: { type: Boolean },
+      autoReload: { type: Boolean }
     },
     attached: function () {
       var slider = new window.SimpleSlider(this, {
@@ -45,6 +46,12 @@
         !this.noAutoPlay && slider.resumeAutoPlay();
       }.bind(this), this.transitionStartDelay || 0);
       this.slider = slider;
+
+      // Reload slider if children nodes are added / removed
+      var me = this;
+      Polymer.dom(this).observeNodes(function(info) {
+        if (me.autoReload) slider.init();
+      });
     },
 
     // Dispose slider on element detach


### PR DESCRIPTION
Related to this [issue](https://github.com/ruyadorno/polymer-simple-slider/issues/5)

If a `dom-repeat` template used within `simple-slider` needs data that is obtained asynchronously, the underlying `SimpleSlider` object may be created before all its children elements are available. 

To resolve this I suggest using `observeNodes ` as recommended in the Polymer [documentation ](https://www.polymer-project.org/1.0/docs/devguide/local-dom#observe-nodes). When children nodes are updated we simply call SimpleSlider's `init()` method.

For a more complete solution we could make use of  `info.addedNodes` and `info.removedNodes` from the `info`object passed in the `observeNodes` callback, to only add / remove updated nodes instead of reloading the whole slider. This would require SimpleSlider to provide something like `addImage` and `removeImage` methods.

